### PR TITLE
CMake: add install rules, respect BUILD_EXAMPLES option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.10)
-project(libperf-cpp)
+project(libperf-cpp VERSION 0.7.0)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_BUILD_TYPE RELEASE)
@@ -31,67 +31,128 @@ include_directories(include/)
 add_library(perf-cpp src/counter.cpp src/group.cpp src/counter_definition.cpp src/event_counter.cpp src/sampler.cpp)
 
 ### Examples
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/examples/bin)
+if(BUILD_EXAMPLES)
+    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/examples/bin)
 
-#### Single-threaded
-add_executable(single-thread EXCLUDE_FROM_ALL examples/single_thread.cpp examples/access_benchmark.cpp)
-target_link_libraries(single-thread perf-cpp)
+    #### Single-threaded
+    add_executable(single-thread EXCLUDE_FROM_ALL examples/single_thread.cpp examples/access_benchmark.cpp)
+    target_link_libraries(single-thread perf-cpp)
 
-#### Multi-threaded; but inherit counter from main-thread
-add_executable(inherit-thread EXCLUDE_FROM_ALL examples/inherit_thread.cpp examples/access_benchmark.cpp)
-target_link_libraries(inherit-thread perf-cpp)
+    #### Multi-threaded; but inherit counter from main-thread
+    add_executable(inherit-thread EXCLUDE_FROM_ALL examples/inherit_thread.cpp examples/access_benchmark.cpp)
+    target_link_libraries(inherit-thread perf-cpp)
 
-#### Multi-threaded with thread-local counter
-add_executable(multi-thread EXCLUDE_FROM_ALL examples/multi_thread.cpp examples/access_benchmark.cpp)
-target_link_libraries(multi-thread perf-cpp)
+    #### Multi-threaded with thread-local counter
+    add_executable(multi-thread EXCLUDE_FROM_ALL examples/multi_thread.cpp examples/access_benchmark.cpp)
+    target_link_libraries(multi-thread perf-cpp)
 
-#### Multi-CPU with per-CPU counter
-add_executable(multi-cpu EXCLUDE_FROM_ALL examples/multi_cpu.cpp examples/access_benchmark.cpp)
-target_link_libraries(multi-cpu perf-cpp)
+    #### Multi-CPU with per-CPU counter
+    add_executable(multi-cpu EXCLUDE_FROM_ALL examples/multi_cpu.cpp examples/access_benchmark.cpp)
+    target_link_libraries(multi-cpu perf-cpp)
 
-#### Multi-Process with per-process counter
-add_executable(multi-process EXCLUDE_FROM_ALL examples/multi_process.cpp examples/access_benchmark.cpp)
-target_link_libraries(multi-process perf-cpp)
+    #### Multi-Process with per-process counter
+    add_executable(multi-process EXCLUDE_FROM_ALL examples/multi_process.cpp examples/access_benchmark.cpp)
+    target_link_libraries(multi-process perf-cpp)
 
-#### Sampling instruction pointers
-add_executable(instruction-pointer-sampling EXCLUDE_FROM_ALL examples/instruction_pointer_sampling.cpp examples/access_benchmark.cpp)
-target_link_libraries(instruction-pointer-sampling perf-cpp)
+    #### Sampling instruction pointers
+    add_executable(instruction-pointer-sampling EXCLUDE_FROM_ALL examples/instruction_pointer_sampling.cpp examples/access_benchmark.cpp)
+    target_link_libraries(instruction-pointer-sampling perf-cpp)
 
-#### Sampling instruction pointers
-add_executable(counter-sampling EXCLUDE_FROM_ALL examples/counter_sampling.cpp examples/access_benchmark.cpp)
-target_link_libraries(counter-sampling perf-cpp)
+    #### Sampling instruction pointers
+    add_executable(counter-sampling EXCLUDE_FROM_ALL examples/counter_sampling.cpp examples/access_benchmark.cpp)
+    target_link_libraries(counter-sampling perf-cpp)
 
-#### Branch sampling
-add_executable(branch-sampling EXCLUDE_FROM_ALL examples/branch_sampling.cpp examples/access_benchmark.cpp)
-target_link_libraries(branch-sampling perf-cpp)
+    #### Branch sampling
+    add_executable(branch-sampling EXCLUDE_FROM_ALL examples/branch_sampling.cpp examples/access_benchmark.cpp)
+    target_link_libraries(branch-sampling perf-cpp)
 
-#### Memory address sampling
-add_executable(address-sampling EXCLUDE_FROM_ALL examples/address_sampling.cpp examples/access_benchmark.cpp)
-target_link_libraries(address-sampling perf-cpp)
+    #### Memory address sampling
+    add_executable(address-sampling EXCLUDE_FROM_ALL examples/address_sampling.cpp examples/access_benchmark.cpp)
+    target_link_libraries(address-sampling perf-cpp)
 
-#### Sampling user_registers
-add_executable(register-sampling EXCLUDE_FROM_ALL examples/register_sampling.cpp examples/access_benchmark.cpp)
-target_link_libraries(register-sampling perf-cpp)
+    #### Sampling user_registers
+    add_executable(register-sampling EXCLUDE_FROM_ALL examples/register_sampling.cpp examples/access_benchmark.cpp)
+    target_link_libraries(register-sampling perf-cpp)
 
-#### Sampling on multiple threads
-add_executable(multi-thread-sampling EXCLUDE_FROM_ALL examples/multi_thread_sampling.cpp examples/access_benchmark.cpp)
-target_link_libraries(multi-thread-sampling perf-cpp)
+    #### Sampling on multiple threads
+    add_executable(multi-thread-sampling EXCLUDE_FROM_ALL examples/multi_thread_sampling.cpp examples/access_benchmark.cpp)
+    target_link_libraries(multi-thread-sampling perf-cpp)
 
-#### Sampling on multiple threads
-add_executable(multi-cpu-sampling EXCLUDE_FROM_ALL examples/multi_cpu_sampling.cpp examples/access_benchmark.cpp)
-target_link_libraries(multi-cpu-sampling perf-cpp)
+    #### Sampling on multiple threads
+    add_executable(multi-cpu-sampling EXCLUDE_FROM_ALL examples/multi_cpu_sampling.cpp examples/access_benchmark.cpp)
+    target_link_libraries(multi-cpu-sampling perf-cpp)
 
-#### Sampling with multiple events
-add_executable(multi-event-sampling EXCLUDE_FROM_ALL examples/multi_event_sampling.cpp examples/access_benchmark.cpp)
-target_link_libraries(multi-event-sampling perf-cpp)
+    #### Sampling with multiple events
+    add_executable(multi-event-sampling EXCLUDE_FROM_ALL examples/multi_event_sampling.cpp examples/access_benchmark.cpp)
+    target_link_libraries(multi-event-sampling perf-cpp)
 
-### One target for all examples
-add_custom_target(examples)
-add_dependencies(examples
-        single-thread inherit-thread multi-thread multi-cpu multi-process
-        instruction-pointer-sampling counter-sampling branch-sampling
-        address-sampling register-sampling multi-thread-sampling multi-cpu-sampling
-        multi-event-sampling)
+    ### One target for all examples
+    add_custom_target(examples)
+    add_dependencies(examples
+            single-thread inherit-thread multi-thread multi-cpu multi-process
+            instruction-pointer-sampling counter-sampling branch-sampling
+            address-sampling register-sampling multi-thread-sampling multi-cpu-sampling
+            multi-event-sampling)
+endif()
 
 ### Target to create the perf list CSV
 add_custom_target(perf-list python3 ${CMAKE_SOURCE_DIR}/script/create_perf_list.py)
+
+### Install rules
+if(PROJECT_IS_TOP_LEVEL)
+  include(CPack)
+endif()
+
+# install rules
+if(PROJECT_IS_TOP_LEVEL)
+  set(CMAKE_INSTALL_INCLUDEDIR include CACHE PATH "")
+  set(CMAKE_INSTALL_BINARY_DIR bin CACHE PATH "")
+endif()
+
+include(CMakePackageConfigHelpers)
+include(GNUInstallDirs)
+# Allow package maintainers to freely override the path for the configs
+set(package perf-cpp)
+
+install(DIRECTORY include/ DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}" COMPONENT perf-cpp_Development)
+install(TARGETS perf-cpp EXPORT perf-cppTargets INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+
+if(BUILD_EXAMPLES)
+    install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/examples/bin/ DESTINATION "${CMAKE_INSTALL_BINARY_DIR}" USE_SOURCE_PERMISSIONS)
+endif()
+
+write_basic_package_version_file(
+    "${package}ConfigVersion.cmake"
+    COMPATIBILITY SameMajorVersion
+    ARCH_INDEPENDENT
+)
+
+set(
+    perf-cpp_INSTALL_CMAKEDIR "${CMAKE_INSTALL_DATADIR}/${package}"
+    CACHE PATH "CMake package config location relative to the install prefix"
+)
+mark_as_advanced(perf-cpp_INSTALL_CMAKEDIR)
+
+write_file(
+    "${PROJECT_BINARY_DIR}/${package}Config.cmake"
+    "include(\"${CMAKE_INSTALL_PREFIX}/${perf-cpp_INSTALL_CMAKEDIR}/${package}Targets.cmake\")"
+)
+
+install(
+    FILES "${PROJECT_BINARY_DIR}/${package}Config.cmake"
+    DESTINATION "${perf-cpp_INSTALL_CMAKEDIR}"
+    COMPONENT perf-cpp_Development
+)
+
+install(
+    FILES "${PROJECT_BINARY_DIR}/${package}ConfigVersion.cmake"
+    DESTINATION "${perf-cpp_INSTALL_CMAKEDIR}"
+    COMPONENT perf-cpp_Development
+)
+
+install(
+    EXPORT perf-cppTargets
+    NAMESPACE perf-cpp::
+    DESTINATION "${perf-cpp_INSTALL_CMAKEDIR}"
+    COMPONENT perf-cpp_Development
+)

--- a/docs/build.md
+++ b/docs/build.md
@@ -2,33 +2,46 @@
 
 ## By hand
 * Download the source code (`git clone https://github.com/jmuehlig/perf-cpp.git`)
-* Within the cloned directory, call `cmake .` to generate the Makefile 
-* Call `make` to generate the project
-* Copy the `include/` directory and the static library `libperf-cpp.a` to your project
-* Include the `include/` folder and link the library: `-lperf-cpp`
+* Within the cloned directory, call `cmake`, optionally define build options, desired targets or an installation prefix:
+  ```
+  cmake -S . -B build -DBUILD_EXAMPLES=ON -DCMAKE_INSTALL_PREFIX=/path/to/libperf-cpp
+  cmake --build build -t perf-cpp -t perf-list -t examples
+  cmake --install build # to installl the library
+  ```
+* Afterwards, the library should be available for discovery with `find_package` (see below).
 
-## Using `CMake` and `ExternalProject`
-* Add `include(ExternalProject)` to your `CMakeLists.txt`
+## Using `CMake` and `FetchContent`
+* Add `include(FetchContent)` to your `CMakeLists.txt`
 * Define an external project:
 ```
-ExternalProject_Add(
+include(FetchContent)
+FetchContent_Declare(
   perf-cpp-external
   GIT_REPOSITORY "https://github.com/jmuehlig/perf-cpp"
   GIT_TAG "v0.7.0"
-  PREFIX "path/to/your/libs/perf-cpp"
-  INSTALL_COMMAND cmake -E echo ""
 )
+FetchContent_MakeAvailable(perf-cpp-external)
 ```
-* Add `path/to/your/libs/perf-cpp/src/perf-cpp-external/include` to your `include_directories()`
+* Add `-DBUILD_SHARED_LIBS=ON` if you want to build a shared library instead of static
 * Add `perf-cpp` to your linked libraries
+* Add `${perf-cpp-external_SOURCE_DIR}/include/` to your include directories
+
+## Using `CMake` and `find_package`
+
+This assumes `perf-cpp` is already installed on your system. Then, it should be enough to call `find_package` and link it against your target:
+
+```
+find_package(perf-cpp REQUIRED)
+target_link_libraries(perf-cpp::perf-cpp)
+```
 
 ## Build Examples
-By default `make` will build the library, but not the examples.
-Use 
 
-    make examples
-
-to build the examples in the `examples/bin` directory.
+Configure the library with `-DBUILD_EXAMPLES=1` and build the `examples` target
+```
+cmake -S . -B build -DBUILD_EXAMPLES=1
+cmake --build build --target examples
+```
 
 ---
 
@@ -39,7 +52,7 @@ If you have an older Kernel, the counter cannot be used and will be deactivated.
 
 ### Linux Kernel version `< 5.12`
 Sampling *weight as struct* (`Type::WeightStruct`, see [sampling documentation](sampling.md)) is only provided since Kernel `5.12`.
-However, you can sample for weight using `Type::Weight`. To avoid compilation errors, you have to define 
+However, you can sample for weight using `Type::Weight`. To avoid compilation errors, you have to define
 
 
     -DNO_PERF_SAMPLE_WEIGHT_STRUCT
@@ -56,4 +69,3 @@ If you have an older Kernel you need to define
 
 
 when compiling the binary that is linked against `libperf-cpp`.
-


### PR DESCRIPTION
Hi,

I hope this will be useful, it makes it easier to package and utilize the library. This PR attempts to add some install rules in `CMakeLists.txt` and additionally checks the `BUILD_EXAMPLES` variable to see if the example executables are needed.

I am not super expert in CMake but these changes work for me. If you prefer to integrate the install rules differently (e.g. include a separate file like `cmake/install-rules.cmake`) please feel free to request any changes.

Thanks
