### PR TITLE
Fallback to no cpu detection on non-x86 systems

### DIFF
--- a/src/counter_definition.cpp
+++ b/src/counter_definition.cpp
@@ -5,8 +5,13 @@
 #include <string_view>
 #include <utility>
 
-#ifndef __builtin_cpu_is
+#if defined(__has_builtin) // supported for gcc >= 10
+#if !__has_builtin(__builtin_cpu_is)
 #define __builtin_cpu_is(x) 0
+#endif
+// If we can't check builtin-support, we assume it is supported (x86 is very likely)
+// #else
+// #define __builtin_cpu_is(x) 0
 #endif
 
 perf::CounterDefinition::CounterDefinition(const std::string& config_file)

--- a/src/counter_definition.cpp
+++ b/src/counter_definition.cpp
@@ -5,13 +5,8 @@
 #include <string_view>
 #include <utility>
 
-#if defined(__has_builtin) // supported for gcc >= 10
-#if !__has_builtin(__builtin_cpu_is)
+#if !(defined(__x86_64__) || defined(__i386__))
 #define __builtin_cpu_is(x) 0
-#endif
-// If we can't check builtin-support, we assume it is supported (x86 is very likely)
-// #else
-// #define __builtin_cpu_is(x) 0
 #endif
 
 perf::CounterDefinition::CounterDefinition(const std::string& config_file)

--- a/src/counter_definition.cpp
+++ b/src/counter_definition.cpp
@@ -5,6 +5,10 @@
 #include <string_view>
 #include <utility>
 
+#ifndef __builtin_cpu_is
+#define __builtin_cpu_is(x) 0
+#endif
+
 perf::CounterDefinition::CounterDefinition(const std::string& config_file)
 {
   this->initialized_default_counters();


### PR DESCRIPTION
`__builtin_cpu_is()` is unsupported on non-x86 systems (see https://github.com/jmuehlig/perf-cpp/issues/3). Unfortunately, it is not trivial, to check support (see https://stackoverflow.com/questions/54079257/how-to-check-builtin-function-is-available-on-gcc). 
gcc supports __has_builtin since version 10, in that case we check wether builtin_cpu_is is supported and overwrite if not.
If it is __has_builtin is not supported we have no fallback. 

