### PR TITLE
use C++11 std decltype instead of typeof

### DIFF
--- a/src/sampler.cpp
+++ b/src/sampler.cpp
@@ -409,11 +409,11 @@ perf::Sampler::read_sample_event(perf::Sampler::UserLevelBufferEntry entry, cons
 
   if (this->_values.is_set(PERF_SAMPLE_READ)) {
     /// Read the number of counters.
-    const auto count_counter_values = entry.read<typeof(CounterReadFormat<Group::MAX_MEMBERS>::count_members)>();
+    const auto count_counter_values = entry.read<decltype(CounterReadFormat<Group::MAX_MEMBERS>::count_members)>();
 
     /// Time enabled and running for correction.
-    const auto time_enabled = entry.read<typeof(CounterReadFormat<Group::MAX_MEMBERS>::time_enabled)>();
-    const auto time_running = entry.read<typeof(CounterReadFormat<Group::MAX_MEMBERS>::time_running)>();
+    const auto time_enabled = entry.read<decltype(CounterReadFormat<Group::MAX_MEMBERS>::time_enabled)>();
+    const auto time_running = entry.read<decltype(CounterReadFormat<Group::MAX_MEMBERS>::time_running)>();
     const auto multiplexing_correction = double(time_enabled) / double(time_running);
 
     /// Read the counters (if the number matches the number of specified counters).


### PR DESCRIPTION
I met compilation errors on 0.8.0.
```
src/sampler.cpp:479:50: error: ‘typeof’ was not declared in this scope; did you mean ‘typedef’?
  479 |     const auto count_counter_values = entry.read<typeof(CounterReadFormat<Group::MAX_MEMBERS>::count_members)>();
      |                                                  ^~~~~~
      |                                                  typedef
```
gcc 14.2.1

It is due to using `typeof`.
Since `typeof` is not a standard C++ feature, please use `decltype` instead.
