### PR TITLE
Don't allocate string when translating error_code to msg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # *perf-cpp*: Changelog
 
-## v1.0.0
+## v1.0
 - **Removed Deprecated Header Files**: All legacy `.h` forwarding headers (e.g., `perfcpp/sampler.h`, `perfcpp/event_counter.h`) have been removed. Use `.hpp` files instead.
 - **Richer Branch Stack Entries**: Each entry in a branch stack sample can now carry additional hardware-reported metadata (see the [sampling documentation](https://jmuehlig.github.io/perf-cpp/sampling/#branch-stack)):
   - **Classification** (Linux 4.15+): the type of branch instruction, i.e., conditional, unconditional, call, return, syscall, and more.

--- a/docs/build.md
+++ b/docs/build.md
@@ -5,7 +5,7 @@
 ```bash
 git clone https://github.com/jmuehlig/perf-cpp.git
 cd perf-cpp
-git checkout v1.0-dev
+git checkout v1.0
 cmake . -B build
 cmake --build build
 ```
@@ -49,7 +49,7 @@ include(FetchContent)
 FetchContent_Declare(
   perf-cpp-external
   GIT_REPOSITORY "https://github.com/jmuehlig/perf-cpp"
-  GIT_TAG "v1.0-dev"
+  GIT_TAG "v1.0"
 )
 FetchContent_MakeAvailable(perf-cpp-external)
 ```
@@ -67,7 +67,7 @@ include(ExternalProject)
 ExternalProject_Add(
   perf-cpp-external
   GIT_REPOSITORY "https://github.com/jmuehlig/perf-cpp"
-  GIT_TAG "v1.0-dev"
+  GIT_TAG "v1.0"
   PREFIX "lib/perf-cpp"
   INSTALL_COMMAND cmake -E echo ""
 )

--- a/include/perfcpp/exception.hpp
+++ b/include/perfcpp/exception.hpp
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 
 namespace perf {
 
@@ -98,7 +99,7 @@ private:
    * @param error_code Error code raised when calling perf_event_open.
    * @return Error message that can be thrown to inform the user.
    */
-  [[nodiscard]] static std::string create_error_message_from_code(std::int64_t error_code);
+  [[nodiscard]] static std::string_view create_error_message_from_code(std::int64_t error_code);
 };
 
 class CannotReadCounter final : public std::runtime_error
@@ -134,7 +135,7 @@ public:
   ~IoctlError() override = default;
 
 protected:
-  [[nodiscard]] static std::string create_error_message_from_code(std::int64_t error_code);
+  [[nodiscard]] static std::string_view create_error_message_from_code(std::int64_t error_code);
 };
 
 class CannotEnableCounter final : public IoctlError

--- a/src/exception.cpp
+++ b/src/exception.cpp
@@ -1,7 +1,7 @@
 #include <perfcpp/exception.hpp>
 #include <perfcpp/feature.h>
 
-std::string
+std::string_view
 perf::CannotOpenCounterError::create_error_message_from_code(const std::int64_t error_code)
 {
   switch (error_code) {
@@ -37,7 +37,7 @@ perf::CannotOpenCounterError::create_error_message_from_code(const std::int64_t 
   }
 }
 
-std::string
+std::string_view
 perf::IoctlError::create_error_message_from_code(const std::int64_t error_code)
 {
   switch (error_code) {


### PR DESCRIPTION
As the caller just appends the message into another `std::string`, we can return `std::string_view` instead and save allocation.