### PR TITLE
Register tests with CTest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # *perf-cpp*: Changelog
 
-## v1.0.0
+## v1.0
 - **Removed Deprecated Header Files**: All legacy `.h` forwarding headers (e.g., `perfcpp/sampler.h`, `perfcpp/event_counter.h`) have been removed. Use `.hpp` files instead.
 - **Richer Branch Stack Entries**: Each entry in a branch stack sample can now carry additional hardware-reported metadata (see the [sampling documentation](https://jmuehlig.github.io/perf-cpp/sampling/#branch-stack)):
   - **Classification** (Linux 4.15+): the type of branch instruction, i.e., conditional, unconditional, call, return, syscall, and more.

--- a/docs/build.md
+++ b/docs/build.md
@@ -5,7 +5,7 @@
 ```bash
 git clone https://github.com/jmuehlig/perf-cpp.git
 cd perf-cpp
-git checkout v1.0-dev
+git checkout v1.0
 cmake . -B build
 cmake --build build
 ```
@@ -49,7 +49,7 @@ include(FetchContent)
 FetchContent_Declare(
   perf-cpp-external
   GIT_REPOSITORY "https://github.com/jmuehlig/perf-cpp"
-  GIT_TAG "v1.0-dev"
+  GIT_TAG "v1.0"
 )
 FetchContent_MakeAvailable(perf-cpp-external)
 ```
@@ -67,7 +67,7 @@ include(ExternalProject)
 ExternalProject_Add(
   perf-cpp-external
   GIT_REPOSITORY "https://github.com/jmuehlig/perf-cpp"
-  GIT_TAG "v1.0-dev"
+  GIT_TAG "v1.0"
   PREFIX "lib/perf-cpp"
   INSTALL_COMMAND cmake -E echo ""
 )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,6 +5,9 @@ FetchContent_Declare(
         GIT_TAG v3.14.0
 )
 FetchContent_MakeAvailable(Catch2)
+list(APPEND CMAKE_MODULE_PATH ${catch2_SOURCE_DIR}/extras)
+include(Catch)
+
 
 set(PERF_CPP_TEST
         test/access_benchmark.cpp
@@ -39,3 +42,6 @@ set_target_properties(tests
         PROPERTIES
         RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
 )
+
+enable_testing()
+catch_discover_tests(tests)


### PR DESCRIPTION
This enables running them with `ctest`, running them in parallel with `ctest -j 0` (at least with newer versions of CMake), and also nicely integrates failing vs skipped tests into the reports.